### PR TITLE
Using Thingsboard 2.3.0 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
         <pkg.win.dist>${project.build.directory}/windows</pkg.win.dist>
-        <thingsboard.version>2.2.1-SNAPSHOT</thingsboard.version>
+        <thingsboard.version>2.3.0</thingsboard.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

Using a release version instead of SNAPSHOT.

Dependencies binaries are currently located in: https://bintray.com/ascentio-tech/maven-thirdparty
